### PR TITLE
Bugfix for TemplateMessagePayload-builder

### DIFF
--- a/src/main/java/com/pocketsunited/mandrill/data/request/TemplateMessagePayload.java
+++ b/src/main/java/com/pocketsunited/mandrill/data/request/TemplateMessagePayload.java
@@ -20,7 +20,7 @@ public class TemplateMessagePayload extends MessagePayload {
             value = "template_content")
     protected List<Variable> templateContent = new ArrayList<Variable>();
 
-    protected static abstract class Init<T extends Init<T,U>, U extends TemplateMessagePayload> extends AbstractPayload.Init<T,U> {
+    protected static abstract class Init<T extends Init<T,U>, U extends TemplateMessagePayload> extends MessagePayload.Init<T,U> {
 
         protected Init(U object) {
             super(object);


### PR DESCRIPTION
I wasn't able to use all necessary methods to build a valid TemplateMessagePayload-object.  The patch makes methods from MessagePayload (e.g. withTo) available when building TemplateMessagePayloads.
