### PR TITLE
Mandrill API: Add css inline feature and adapt TemplateMessagePayload to extends MessagePayload

### DIFF
--- a/src/main/java/com/pocketsunited/mandrill/data/request/MessagePayload.java
+++ b/src/main/java/com/pocketsunited/mandrill/data/request/MessagePayload.java
@@ -221,7 +221,11 @@ public class MessagePayload extends AbstractPayload {
         protected List<Recipient> to = new ArrayList<Recipient>();
 
         @JsonProperty(
-                value = "track_opens")
+                 value = "inline_css")
+        protected boolean inlineCss = Boolean.FALSE;
+
+        @JsonProperty(
+              value = "track_opens")
         protected boolean trackOpens = Boolean.FALSE;
 
         @JsonProperty(
@@ -326,6 +330,16 @@ public class MessagePayload extends AbstractPayload {
             return withRecipient(new Recipient(email, name));
         }
 
+        public T withInlineCss(){
+          object.message.inlineCss = Boolean.TRUE;
+          return self();
+        }
+
+        public T withoutInlineCss(){
+          object.message.inlineCss = Boolean.FALSE;
+          return self();
+        }
+        
         public T withTrackOpens() {
             object.message.trackOpens = Boolean.TRUE;
             return self();

--- a/src/main/java/com/pocketsunited/mandrill/data/request/TemplateMessagePayload.java
+++ b/src/main/java/com/pocketsunited/mandrill/data/request/TemplateMessagePayload.java
@@ -20,7 +20,7 @@ public class TemplateMessagePayload extends MessagePayload {
             value = "template_content")
     protected List<Variable> templateContent = new ArrayList<Variable>();
 
-    protected static abstract class Init<T extends Init<T,U>, U extends TemplateMessagePayload> extends AbstractPayload.Init<T,U> {
+    protected static abstract class Init<T extends Init<T,U>, U extends TemplateMessagePayload> extends MessagePayload.Init<T,U> {
 
         protected Init(U object) {
             super(object);


### PR DESCRIPTION
Hello, 

i got two pulls which might be interesting  for you. 
- I added the inline css feature for sending mails via mandrill with this feature
- adapt TemplateMessagePayload to extends MessagePayload
  (this PR might has already be requested by an college)

best regards Matthias 
